### PR TITLE
Added specific font imports.

### DIFF
--- a/src/theme/foundations/fonts.ts
+++ b/src/theme/foundations/fonts.ts
@@ -1,0 +1,23 @@
+// If we are to use some font properties, we need to specifically import the font property css file (Otherwise some font properties will not work).
+
+// If we need to use a specific font weight (Some fonts have multiple weights and they won't work by default), we need to import the font weight css file.)";
+import "@fontsource/outfit/100.css" // fontWeigth={thin}
+import "@fontsource/outfit/200.css" // fontWeigth={extralight}
+import "@fontsource/outfit/300.css" // fontWeigth={light}
+import "@fontsource/outfit/400.css" // fontWeigth={normal}
+import "@fontsource/outfit/500.css" // fontWeigth={medium}
+import "@fontsource/outfit/600.css" // fontWeigth={semibold}
+import "@fontsource/outfit/700.css" // fontWeigth={bold}
+import "@fontsource/outfit/800.css" // fontWeigth={extrabold}
+import "@fontsource/outfit/900.css" // fontWeigth={black}
+
+// If we need to use a specific font style in some cases we need to import the font style css file.
+import "@fontsource/outfit/100italic.css" // fontWeigth={thin} fontStyle={italic}
+import "@fontsource/outfit/200italic.css" // fontWeigth={extralight} fontStyle={italic}
+import "@fontsource/outfit/300italic.css" // fontWeigth={light} fontStyle={italic}
+import "@fontsource/outfit/400italic.css" // fontWeigth={normal} fontStyle={italic}
+import "@fontsource/outfit/500italic.css" // fontWeigth={medium} fontStyle={italic}
+import "@fontsource/outfit/600italic.css" // fontWeigth={semibold} fontStyle={italic}
+import "@fontsource/outfit/700italic.css" // fontWeigth={bold} fontStyle={italic}
+import "@fontsource/outfit/800italic.css" // fontWeigth={extrabold} fontStyle={italic}
+import "@fontsource/outfit/900italic.css" // fontWeigth={black} fontStyle={italic}

--- a/src/theme/foundations/typography.ts
+++ b/src/theme/foundations/typography.ts
@@ -1,3 +1,5 @@
+import "./fonts"
+
 export const textSpecs = {
   /**
    * Text Sizes are built using the 4pt system (aka a multiplaction of 4)


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/Daniel-Manea/next-baseline/main?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=Daniel-Manea&repo=next-baseline&branch=main">VS Code</a>

<!-- open-in-codesandbox:complete -->


I encountered a problem when trying to use some font properties like font-weight. It does not work by just importing the hole font:

import "@fontsource/font-name"

instead, I had to use: 

import "@fontsource/font-name/font-weigth.css"